### PR TITLE
Disabling templated icons on macOS, enabling colorized icons

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"fyne.io/systray"
-	"fyne.io/systray/example/icon"
+	"github.com/kolide/systray"
+	"github.com/kolide/systray/example/icon"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module fyne.io/systray
+module github.com/kolide/systray
 
 go 1.13
 

--- a/systray_darwin.go
+++ b/systray_darwin.go
@@ -21,7 +21,7 @@ import (
 // .ico/.jpg/.png for other platforms.
 func SetTemplateIcon(templateIconBytes []byte, regularIconBytes []byte) {
 	cstr := (*C.char)(unsafe.Pointer(&templateIconBytes[0]))
-	C.setIcon(cstr, (C.int)(len(templateIconBytes)), true)
+	C.setIcon(cstr, (C.int)(len(templateIconBytes)), false) // Explicitly NOT setting template bool, so we get colorized icons
 }
 
 // SetIcon sets the icon of a menu item. Only works on macOS and Windows.

--- a/systray_menu_unix.go
+++ b/systray_menu_unix.go
@@ -9,7 +9,7 @@ import (
 	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/prop"
 
-	"fyne.io/systray/internal/generated/menu"
+	"github.com/kolide/systray/internal/generated/menu"
 )
 
 // SetIcon sets the icon of a menu item.

--- a/systray_unix.go
+++ b/systray_unix.go
@@ -20,8 +20,8 @@ import (
 	"github.com/godbus/dbus/v5/introspect"
 	"github.com/godbus/dbus/v5/prop"
 
-	"fyne.io/systray/internal/generated/menu"
-	"fyne.io/systray/internal/generated/notifier"
+	"github.com/kolide/systray/internal/generated/menu"
+	"github.com/kolide/systray/internal/generated/notifier"
 )
 
 const (


### PR DESCRIPTION
This disables the [template property](https://developer.apple.com/documentation/appkit/nsimage/1520017-template) on menu bar icons for macOS. With templating turned off, icons are rendered with color.