### PR TITLE
Adding support for watching NSStatusItem appearance changes

### DIFF
--- a/systray.go
+++ b/systray.go
@@ -123,6 +123,12 @@ func Register(onReady func(), onExit func(), onAppearanceChanged func(bool)) {
 	}
 	systrayExit = onExit
 	systrayExitCalled = false
+
+	if onAppearanceChanged == nil {
+		onAppearanceChanged = func(bool) {}
+	}
+	systrayOnAppearanceChanged = onAppearanceChanged
+
 	registerSystray()
 }
 
@@ -269,7 +275,5 @@ func systrayMenuItemSelected(id uint32) {
 }
 
 func systrayAppearanceChanged(dark bool) {
-	if systrayOnAppearanceChanged != nil {
-		systrayOnAppearanceChanged(dark)
-	}
+	systrayOnAppearanceChanged(dark)
 }

--- a/systray.go
+++ b/systray.go
@@ -10,11 +10,12 @@ import (
 )
 
 var (
-	systrayReady      func()
-	systrayExit       func()
-	systrayExitCalled bool
-	menuItems         = make(map[uint32]*MenuItem)
-	menuItemsLock     sync.RWMutex
+	systrayReady               func()
+	systrayExit                func()
+	systrayOnAppearanceChanged func(bool)
+	systrayExitCalled          bool
+	menuItems                  = make(map[uint32]*MenuItem)
+	menuItemsLock              sync.RWMutex
 
 	currentID = uint32(0)
 	quitOnce  sync.Once
@@ -78,17 +79,17 @@ func newMenuItem(title string, tooltip string, parent *MenuItem) *MenuItem {
 
 // Run initializes GUI and starts the event loop, then invokes the onReady
 // callback. It blocks until systray.Quit() is called.
-func Run(onReady, onExit func()) {
+func Run(onReady, onExit func(), onAppearanceChanged func(bool)) {
 	setInternalLoop(true)
-	Register(onReady, onExit)
+	Register(onReady, onExit, onAppearanceChanged)
 
 	nativeLoop()
 }
 
 // RunWithExternalLoop allows the systemtray module to operate with other tookits.
 // The returned start and end functions should be called by the toolkit when the application has started and will end.
-func RunWithExternalLoop(onReady, onExit func()) (start, end func()) {
-	Register(onReady, onExit)
+func RunWithExternalLoop(onReady, onExit func(), onAppearanceChanged func(bool)) (start, end func()) {
+	Register(onReady, onExit, onAppearanceChanged)
 
 	return nativeStart, func() {
 		nativeEnd()
@@ -101,7 +102,7 @@ func RunWithExternalLoop(onReady, onExit func()) (start, end func()) {
 // needs to show other UI elements, for example, webview.
 // To overcome some OS weirdness, On macOS versions before Catalina, calling
 // this does exactly the same as Run().
-func Register(onReady func(), onExit func()) {
+func Register(onReady func(), onExit func(), onAppearanceChanged func(bool)) {
 	if onReady == nil {
 		systrayReady = func() {}
 	} else {
@@ -264,5 +265,11 @@ func systrayMenuItemSelected(id uint32) {
 	case item.ClickedCh <- struct{}{}:
 	// in case no one waiting for the channel
 	default:
+	}
+}
+
+func systrayAppearanceChanged(dark bool) {
+	if systrayOnAppearanceChanged != nil {
+		systrayOnAppearanceChanged(dark)
 	}
 }

--- a/systray.h
+++ b/systray.h
@@ -3,6 +3,7 @@
 extern void systray_ready();
 extern void systray_on_exit();
 extern void systray_menu_item_selected(int menu_id);
+extern void systray_appearance_changed(bool dark);
 void registerSystray(void);
 void nativeEnd(void);
 int nativeLoop(void);

--- a/systray_darwin.go
+++ b/systray_darwin.go
@@ -151,3 +151,8 @@ func systray_on_exit() {
 func systray_menu_item_selected(cID C.int) {
 	systrayMenuItemSelected(uint32(cID))
 }
+
+//export systray_appearance_changed
+func systray_appearance_changed(dark C.bool) {
+	systrayAppearanceChanged(bool(dark))
+}

--- a/systray_darwin.m
+++ b/systray_darwin.m
@@ -71,7 +71,22 @@ withParentMenuId: (int)theParentMenuId
   self->menu = [[NSMenu alloc] init];
   [self->menu setAutoenablesItems: FALSE];
   [self->statusItem setMenu:self->menu];
+  [self->statusItem addObserver:self forKeyPath:@"button.effectiveAppearance" options:NSKeyValueObservingOptionNew|NSKeyValueObservingOptionInitial context:nil];
   systray_ready();
+}
+
+-(void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context
+{
+    if ([keyPath isEqualToString:@"button.effectiveAppearance"]) {
+        NSStatusItem *item = object;
+        NSAppearance *appearance = item.button.effectiveAppearance;
+        NSString *appearanceName = (NSString*)(appearance.name);
+        if ([[appearanceName lowercaseString] containsString:@"dark"]) {
+          systray_appearance_changed(true);
+        } else {
+          systray_appearance_changed(false);
+        }
+    }
 }
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification


### PR DESCRIPTION
This PR adds functionality to our systray fork to get notifications when the menu bar icon appearance changes. This is more accurate dark mode detection essentially.

See: https://github.com/yujitach/nsstatusitem-lightdark-detect/blob/main/nsstatusitem-lightdark-detect/AppDelegate.m