### PR TITLE
show systray only when show called

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -15,6 +15,12 @@ func main() {
 	}
 	input := make(chan string, 1)
 
+	go func() {
+		// can use some other condition here to wait to show the systray
+		time.Sleep(2 * time.Second)
+		systray.Show()
+	}()
+
 	systray.Run(onReady, onExit, func(b bool) {}, input)
 }
 

--- a/systray.go
+++ b/systray.go
@@ -12,6 +12,11 @@ import (
 var (
 	SystrayMenuOpened = make(chan struct{})
 
+	showChan = make(chan struct{})
+	showOnce = sync.OnceFunc(func() {
+		showChan <- struct{}{}
+	})
+
 	systrayReady               func()
 	systrayExit                func()
 	systrayOnAppearanceChanged func(bool)
@@ -88,6 +93,7 @@ func Run(onReady, onExit func(), onAppearanceChanged func(bool), input chan stri
 	setInternalLoop(true)
 	Register(onReady, onExit, onAppearanceChanged)
 
+	<-showChan
 	nativeLoop()
 }
 
@@ -100,6 +106,10 @@ func RunWithExternalLoop(onReady, onExit func(), onAppearanceChanged func(bool))
 		nativeEnd()
 		Quit()
 	}
+}
+
+func Show() {
+	showOnce()
 }
 
 // Register initializes GUI and registers the callbacks but relies on the


### PR DESCRIPTION
Don't show systray until "show" is called so that we can choose to run hidden.